### PR TITLE
docs: add decision queue for human-review items

### DIFF
--- a/docs/decision-queue.md
+++ b/docs/decision-queue.md
@@ -1,0 +1,20 @@
+# Decision Queue
+
+Items requiring human review, curated by AI agent sessions and the
+automated tooling patrol (see hironow/dotfiles routine). Append new
+entries under a dated section; tick the checkbox (or delete the entry)
+once the human has decided.
+
+Entry format:
+
+```markdown
+## YYYY-MM-DD
+
+- [ ] **<topic>**: <decision needed> — background / options / recommendation
+```
+
+---
+
+## Open Items
+
+(none yet)


### PR DESCRIPTION
Adds `docs/decision-queue.md` — the per-repo inbox for decisions that need a human,
written to by AI agent sessions and the tooling patrol routine (see hironow/dotfiles).

Entries are appended under dated sections as `- [ ] **<topic>**: ...` checklist items;
tick or delete once decided. Seeded empty.
