### PR TITLE
test(field-coverage): triage new ADK 1.34 event/part fields

### DIFF
--- a/experiments/2025-12-12_adk_field_mapping_completeness.md
+++ b/experiments/2025-12-12_adk_field_mapping_completeness.md
@@ -228,6 +228,7 @@ Transcription(
 |-----------|---------------|-------------------|----------|-------|
 | `content` | ✅ Implemented | `start` → parts processing | Critical | Core message content |
 | `turnComplete` | ✅ Implemented | `finish` event | Critical | Signals end of turn |
+| `turnCompleteReason` | ❌ Not implemented | TBD | Medium | Why the turn completed, companion to `turnComplete` (added by ADK 1.34) |
 | `usageMetadata` | ✅ Implemented | `finish.messageMetadata.usage` | High | Token usage stats |
 | `finishReason` | ✅ Implemented | `finish.finishReason` | High | Why generation stopped |
 | `outputTranscription` | ✅ Implemented (2025-12-12) | `text-start/delta/end` | High | Native-audio model transcription |
@@ -238,6 +239,8 @@ Transcription(
 | `avgLogprobs` | ❌ Not implemented | TBD | Low | Average log probabilities |
 | `cacheMetadata` | ✅ Implemented (2025-12-13) | `finish.messageMetadata.cache` | Low | Context caching info (components/message.tsx:506-529) |
 | `liveSessionResumptionUpdate` | ❌ Not implemented | TBD | Low | Session resumption state |
+| `liveSessionId` | ❌ Not implemented | TBD | Low | Live session identifier (added by ADK 1.34) |
+| `goAway` | ❌ Not implemented | TBD | Medium | Live API imminent-disconnect notice, BIDI reconnect UX (added by ADK 1.34) |
 | `errorCode` | ✅ Implemented (2025-12-13) | `error` event (immediate detection) | Critical | Error signaling (stream_protocol.py:181-187) |
 | `errorMessage` | ✅ Implemented (2025-12-13) | `error` event (immediate detection) | Critical | Error details (stream_protocol.py:181-187) |
 | `interrupted` | ❌ Not implemented | TBD | Medium | Interruption signal |
@@ -260,6 +263,8 @@ Transcription(
 | `thought` | ✅ Implemented | Custom event `thought` | High | Reasoning/thinking mode |
 | `functionCall` | ✅ Implemented | `tool-input-start/available` | Critical | Tool invocation |
 | `functionResponse` | ✅ Implemented | `tool-output-available` | Critical | Tool result |
+| `toolCall` | ❌ Not implemented | TBD | Medium | Server-side tool call, unused by this app's agents (added by google-genai for ADK 1.34) |
+| `toolResponse` | ❌ Not implemented | TBD | Medium | Server-side tool response, pairs with `toolCall` (added by google-genai for ADK 1.34) |
 | `executableCode` | ✅ Implemented | `code-delta` | High | Code execution |
 | `codeExecutionResult` | ✅ Implemented | `code-delta` | High | Execution output |
 | `inlineData` | ✅ Implemented | `data-pcm` (audio) | High | Binary data (PCM audio) |
@@ -267,6 +272,7 @@ Transcription(
 | `videoMetadata` | ❌ Not implemented | TBD | Low | Video metadata |
 | `thoughtSignature` | ❌ Not implemented | TBD | Low | Thought verification |
 | `mediaResolution` | ❌ Not implemented | TBD | Low | Media resolution info |
+| `partMetadata` | ❌ Not implemented | TBD | Low | Custom per-part metadata, e.g. source file tracking (added by google-genai for ADK 1.34) |
 
 ---
 

--- a/tests/unit/test_field_coverage.py
+++ b/tests/unit/test_field_coverage.py
@@ -40,6 +40,8 @@ IMPLEMENTED_EVENT_FIELDS = {
 # Fields we know about but haven't implemented yet (with justification)
 DOCUMENTED_EVENT_FIELDS = {
     "interrupted": "Medium priority: BIDI UX feature for user interruption",
+    "turnCompleteReason": "Medium priority: why the turn completed, companion to turnComplete (added by ADK 1.34)",
+    "goAway": "Medium priority: Live API imminent-disconnect notice, BIDI reconnect UX (added by ADK 1.34)",
 }
 
 # Internal/metadata fields (low priority, documented why skipped)
@@ -52,6 +54,7 @@ METADATA_EVENT_FIELDS = {
     "id": "Event ID (internal)",
     "interactionId": "Interactions API state management ID (added in ADK 1.21.0)",
     "invocationId": "Invocation tracking ID",
+    "liveSessionId": "Live session identifier (internal, added by ADK 1.34)",
     "liveSessionResumptionUpdate": "Live session state sync",
     "logprobsResult": "Advanced feature: token log probabilities",
     "longRunningToolIds": "ADK long-running tool tracking",
@@ -79,11 +82,14 @@ IMPLEMENTED_PART_FIELDS = {
 DOCUMENTED_PART_FIELDS = {
     "fileData": "Medium priority: Multi-modal file support (GCS URLs)",
     "videoMetadata": "Low priority: Video-specific metadata",
+    "toolCall": "Medium priority: server-side tool call flow, unused by this app's agents (added by google-genai for ADK 1.34)",
+    "toolResponse": "Medium priority: server-side tool response flow, pairs with toolCall (added by google-genai for ADK 1.34)",
 }
 
 # Part metadata fields
 METADATA_PART_FIELDS = {
     "mediaResolution": "Media resolution info (not forwarded)",
+    "partMetadata": "Custom per-part metadata, e.g. source file tracking (not forwarded)",
     "thoughtSignature": "Advanced: Thought verification signature",
     "value": "Unknown purpose - needs investigation",
 }


### PR DESCRIPTION
## Summary

The field-coverage tripwire (`tests/unit/test_field_coverage.py`) has been failing since the google-adk 1.22 → 1.3x bump (#11): the SDK added 3 Event fields and 3 Part fields that were never consciously triaged. This PR performs that triage per the test's own documented workflow — no production code change.

## Triage decisions

| Field | Class | Rationale |
|---|---|---|
| Event.`turnCompleteReason` | DOCUMENTED (medium) | Companion to the implemented `turnComplete`; worth exposing on BIDI `finish` later |
| Event.`goAway` | DOCUMENTED (medium) | Live API imminent-disconnect notice — BIDI reconnect UX material |
| Event.`liveSessionId` | METADATA | Internal live-session identifier (same class as `liveSessionResumptionUpdate`) |
| Part.`toolCall` | DOCUMENTED (medium) | Server-side tool call flow (`{id, tool_type, args}`); unused by this app's agents today |
| Part.`toolResponse` | DOCUMENTED (medium) | Pairs with `toolCall` |
| Part.`partMetadata` | METADATA | Per-part custom metadata (e.g. source-file tracking), not forwarded |

`experiments/2025-12-12_adk_field_mapping_completeness.md` matrix updated with the same rows.

## Test results

- `tests/unit/test_field_coverage.py`: **3 passed** (was 2 failed)
- Full suite (excl. `tests/e2e/requires_server`): **18 → 16 failures**
- The remaining 16 are all API-key-gated: 5 raise `ValueError: No API key was provided` directly, 11 see an `error` event instead of a stream because the in-process server has no `GOOGLE_API_KEY` (fresh clone without `.env`). They should pass on a machine with a populated `.env`. Verified identical on google-adk 1.34.3 and 1.35.0 — not version skew.
- mypy clean, md-lint 0 errors