### PR TITLE
refactor(lint): clear ruff 0.15 / biome lint debt (StrEnum, optional chains)

### DIFF
--- a/adk_stream_protocol/protocol/message_types.py
+++ b/adk_stream_protocol/protocol/message_types.py
@@ -34,7 +34,7 @@ Tool Call States (UIToolInvocation):
 """
 
 import base64
-from enum import Enum
+from enum import StrEnum
 from io import BytesIO
 from typing import Any, Literal
 
@@ -67,7 +67,7 @@ def _extract_image_metadata(image_bytes: bytes) -> tuple[int, int, str | None]:
 # ============================================================
 
 
-class ToolCallState(str, Enum):
+class ToolCallState(StrEnum):
     """
     Tool call state values (AI SDK v6 UIToolInvocation states).
 

--- a/adk_stream_protocol/protocol/stream_protocol.py
+++ b/adk_stream_protocol/protocol/stream_protocol.py
@@ -86,7 +86,7 @@ def format_sse_event(event_data: dict[str, Any]) -> SseFormattedEvent:
     return f"data: {json.dumps(event_data)}\n\n"
 
 
-class AISdkFinishReason(str, enum.Enum):
+class AISdkFinishReason(enum.StrEnum):
     """
     AI SDK v6 FinishReason values.
 

--- a/lib/tests/e2e/bidi-sequential-only-execution.e2e.test.tsx
+++ b/lib/tests/e2e/bidi-sequential-only-execution.e2e.test.tsx
@@ -81,8 +81,7 @@ describe("BIDI Sequential-Only Execution (ADR 0003)", () => {
           firstApprovalSent &&
           !firstApprovalResolved &&
           msg.type === "message" &&
-          msg.messages &&
-          msg.messages[msg.messages.length - 1].parts?.some(
+          msg.messages?.[msg.messages.length - 1].parts?.some(
             (p: any) =>
               p.type === "tool-process_payment" &&
               p.state === "approval-responded" &&
@@ -135,8 +134,7 @@ describe("BIDI Sequential-Only Execution (ADR 0003)", () => {
         if (
           secondApprovalSent &&
           msg.type === "message" &&
-          msg.messages &&
-          msg.messages[msg.messages.length - 1].parts?.some(
+          msg.messages?.[msg.messages.length - 1].parts?.some(
             (p: any) =>
               p.type === "tool-process_payment" &&
               p.state === "approval-responded" &&

--- a/lib/tests/e2e/multi-tool-execution-e2e.test.tsx
+++ b/lib/tests/e2e/multi-tool-execution-e2e.test.tsx
@@ -156,7 +156,7 @@ describe("Multi-Tool Execution E2E Tests", () => {
         () => {
           const lastMessage =
             result.current.messages[result.current.messages.length - 1];
-          if (!lastMessage || lastMessage.role !== "assistant") return false;
+          if (lastMessage?.role !== "assistant") return false;
 
           const confirmationPart = lastMessage.parts.find((part) =>
             isApprovalRequestedTool(part),
@@ -191,7 +191,7 @@ describe("Multi-Tool Execution E2E Tests", () => {
         () => {
           const messages = result.current.messages;
           const lastMessage = messages[messages.length - 1];
-          if (!lastMessage || lastMessage.role !== "assistant") return false;
+          if (lastMessage?.role !== "assistant") return false;
 
           // Look for Tool2 confirmation specifically
           const tool2Part = lastMessage.parts.find(

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -338,7 +338,7 @@ class ADKAnalyzer:
         event_access_pattern = r"\bevent\.(\w+)\b(?!\s*\()"
         for match in re.finditer(event_access_pattern, content):
             field_name = match.group(1)
-            if not field_name.startswith("_") and field_name not in ("content",):
+            if not field_name.startswith("_") and field_name != "content":
                 event_fields.add(field_name)
 
         # Pattern 2b: getattr(event, "field_name")


### PR DESCRIPTION
## Summary

Clears the lint debt surfaced by linter-version drift — `just lint-py` and the safe portion of `lint-ts` now pass. Structural changes only, no behavior change.

## Changes

**Python (ruff 0.15.x, 3 findings → 0)**
- UP042: `ToolCallState` / `AISdkFinishReason` now inherit `enum.StrEnum` instead of `(str, Enum)`. Audited every usage first: both enums appear only in equality/membership comparisons, `.value` reads, and as pydantic field types — no `str()` / f-string coercion sites, so the `str()` behavior change of StrEnum ('ClassName.MEMBER' → 'value') cannot bite.
- FURB171: `field_name not in ("content",)` → `field_name != "content"` in `scripts/check-coverage.py`.

**TypeScript (biome, 4 useOptionalChain warnings → 0)**
- `!lastMessage || lastMessage.role !== "assistant"` → `lastMessage?.role !== "assistant"` (×2, multi-tool e2e)
- `msg.messages && msg.messages[...].parts?.some(...)` → `msg.messages?.[...]` (×2, bidi-sequential e2e)

## Deliberately NOT fixed

The 9 biome `noArrayIndexKey` errors in `components/message.tsx`: streamed message-part lists have no stable IDs, `key={index}` may be intentional, and changing keys affects React reconciliation — needs a design decision rather than a mechanical fix.

## Verification

- `uv run ruff check .` → All checks passed
- `uv run mypy .` → clean (106 files)
- `uv run pytest tests/unit` → 322 passed
- `bun run vitest run` on both edited files → 4/4 passed
- biome: 4 warnings gone; only the deferred noArrayIndexKey errors remain