### PR TITLE
test(conftest): skip external-dependency tests when creds/server absent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ exclude = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+markers = [
+    "requires_api: calls the real Gemini API; skipped when GOOGLE_API_KEY is missing or rejected",
+    "requires_server: needs the local backend server (just server); skipped when unreachable",
+]
 # Filter third-party deprecation warnings (keep our own warnings visible)
 filterwarnings = [
     # litellm: asyncio.iscoroutinefunction deprecated in Python 3.16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,11 @@ unit, integration, and E2E tests.
 """
 
 import base64
+import functools
+import os
+import socket
+import urllib.error
+import urllib.request
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -19,6 +24,75 @@ load_dotenv(".env.local")
 
 from adk_stream_protocol import FrontendToolDelegate  # noqa: E402
 from adk_stream_protocol.protocol.id_mapper import IDMapper  # noqa: E402
+
+
+# ============================================================
+# External-dependency gating (requires_api / requires_server)
+# ============================================================
+
+
+@functools.cache
+def _gemini_api_key_status() -> tuple[str, str]:
+    """Probe the Gemini API once per session to classify the configured key.
+
+    Returns (status, reason). status is one of:
+    - "ok": key accepted by the API
+    - "missing": GOOGLE_API_KEY is not set
+    - "invalid": the API rejected the key (expired, revoked, malformed)
+    - "unverifiable": probe could not complete (offline, quota) — tests run
+
+    The probe is a single models-list request (no LLM tokens consumed).
+    """
+    key = os.environ.get("GOOGLE_API_KEY", "")
+    if not key:
+        return "missing", "GOOGLE_API_KEY is not set (populate .env.local)"
+    request = urllib.request.Request(
+        "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1",
+        headers={"x-goog-api-key": key},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5):
+            return "ok", ""
+    except urllib.error.HTTPError as error:
+        if error.code in (400, 401, 403):
+            return "invalid", f"Gemini API rejected GOOGLE_API_KEY (HTTP {error.code})"
+        return "unverifiable", f"Gemini API probe failed (HTTP {error.code})"
+    except OSError as error:
+        return "unverifiable", f"Gemini API unreachable: {error}"
+
+
+@functools.cache
+def _backend_server_reachable() -> bool:
+    """Check once per session whether the local backend server is up."""
+    port = int(os.environ.get("BACKEND_PORT", "8000"))
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=2):
+            return True
+    except OSError:
+        return False
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-mark everything under tests/e2e/requires_server/."""
+    for item in items:
+        if "requires_server" in item.path.parts:
+            item.add_marker(pytest.mark.requires_api)
+            item.add_marker(pytest.mark.requires_server)
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip (not fail) external-dependency tests when the dependency is absent.
+
+    A failing test must mean broken code; a missing/expired credential or a
+    stopped server is an environment condition and reads as a skip reason.
+    """
+    if item.get_closest_marker("requires_api") is not None:
+        status, reason = _gemini_api_key_status()
+        if status in ("missing", "invalid"):
+            pytest.skip(f"requires a live Gemini API key: {reason}")
+    if item.get_closest_marker("requires_server") is not None and not _backend_server_reachable():
+        port = int(os.environ.get("BACKEND_PORT", "8000"))
+        pytest.skip(f"requires the backend server on localhost:{port} (start with `just server`)")
 
 
 # ============================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def _gemini_api_key_status() -> tuple[str, str]:
         headers={"x-goog-api-key": key},
     )
     try:
-        with urllib.request.urlopen(request, timeout=5):
+        # S310 audited: the URL is the fixed https:// literal above
+        with urllib.request.urlopen(request, timeout=5):  # noqa: S310
             return "ok", ""
     except urllib.error.HTTPError as error:
         if error.code in (400, 401, 403):

--- a/tests/integration/test_deferred_approval_flow.py
+++ b/tests/integration/test_deferred_approval_flow.py
@@ -31,6 +31,9 @@ from adk_stream_protocol.ags import BIDI_MODEL
 
 load_dotenv(".env.local")
 
+# Drives a live BIDI session against the real Gemini API — skip without a live key
+pytestmark = pytest.mark.requires_api
+
 # Enable ADK debug logging to see what's sent to Live API
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/integration/test_deferred_approval_flow_blocking.py
+++ b/tests/integration/test_deferred_approval_flow_blocking.py
@@ -36,6 +36,9 @@ from .test_deferred_approval_flow import ApprovalQueue
 
 load_dotenv(".env.local")
 
+# Drives a live BIDI session against the real Gemini API — skip without a live key
+pytestmark = pytest.mark.requires_api
+
 # Enable ADK debug logging
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/integration/test_live_request_queue_during_blocking.py
+++ b/tests/integration/test_live_request_queue_during_blocking.py
@@ -32,6 +32,9 @@ from adk_stream_protocol.ags import BIDI_MODEL
 
 load_dotenv(".env.local")
 
+# Drives a live BIDI session against the real Gemini API — skip without a live key
+pytestmark = pytest.mark.requires_api
+
 # Enable ADK debug logging
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/integration/test_server_structure_validation.py
+++ b/tests/integration/test_server_structure_validation.py
@@ -29,9 +29,14 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from server import app
+
+
+# Real LLM API calls by design (no mocks for structure tests) — skip without a live key
+pytestmark = pytest.mark.requires_api
 
 
 # Default API key for development/test

--- a/tests/integration/test_websocket_bidi_validation.py
+++ b/tests/integration/test_websocket_bidi_validation.py
@@ -23,6 +23,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from fastapi.testclient import TestClient
 
 from server import app
@@ -75,6 +76,7 @@ def has_required_fields(actual: dict[str, Any], expected: dict[str, Any]) -> boo
     return expected_fields.issubset(actual_fields)
 
 
+@pytest.mark.requires_api
 class TestWebSocketBIDIStructure:
     """
     E2E tests for WebSocket /live endpoint (ADK BIDI mode).
@@ -251,6 +253,7 @@ class TestWebSocketEventSequence:
                 )
                 assert first_message.endswith("\n\n"), "SSE messages should end with double newline"
 
+    @pytest.mark.requires_api
     def test_websocket_has_start_event(self):
         """WebSocket stream should start with 'start' event."""
         # Given: Any message
@@ -312,6 +315,7 @@ class TestWebSocketEventSequence:
                 assert events[-1] == "[DONE]", "Stream should end with [DONE] marker"
 
 
+@pytest.mark.requires_api
 class TestWebSocketRequiredFields:
     """Tests for required fields in WebSocket events."""
 


### PR DESCRIPTION
## Problem

A missing or expired `GOOGLE_API_KEY` made 37 tests **fail** in misleading ways — 5 with a clear `No API key` error, 32 disguised as protocol bugs (a lone `error` event, `Event count mismatch: got 1, expected 8`). The suite could not distinguish "broken code" from "cannot verify in this environment", and diagnosing that cost real time today (an expired key from another project produced the identical signature).

## Change

Two pytest markers, applied per the no-mocks-in-e2e house policy (the tests keep hitting the real API — they just declare their dependency honestly):

- **`requires_api`** — skipped when `GOOGLE_API_KEY` is missing **or rejected by the API**. Validity is probed once per session via a `models?pageSize=1` request (no LLM tokens). If the probe itself can't complete (offline / quota), status is "unverifiable" and tests **run** — the mechanism never hides a real failure.
- **`requires_server`** — skipped when the backend (`just server`, `BACKEND_PORT` default 8000) is unreachable.
- `tests/e2e/requires_server/**` is auto-marked with both (conftest collection hook).
- Explicit `pytestmark` on the 4 integration files whose every test drives a live Gemini session; per-class/per-test marks in `test_websocket_bidi_validation.py`, where 2 of 6 tests run keyless and deliberately stay unmarked.

## Verification

| state | result |
|---|---|
| no `.env.local` | `37 skipped` — "GOOGLE_API_KEY is not set (populate .env.local)", 0.01s |
| expired key | `37 skipped` — "Gemini API rejected GOOGLE_API_KEY (HTTP 400)", one probe request |
| full suite (expired key) | **365 passed / 37 skipped / 2 failed** — the 2 are the field-coverage tripwire, fixed in #13 |

mypy clean (106 files). The 3 ruff findings visible on this branch are pre-existing and fixed in #14.

## Not in scope

Whether the 16 real-API integration tests should be reclassified as e2e or rewritten against a fake model (house rule allows mocks below e2e) — that's a design decision, tracked separately.